### PR TITLE
Some Minor Improvements

### DIFF
--- a/02_Feature_Extraction/Randomness/BinaryRatio_FFC.m
+++ b/02_Feature_Extraction/Randomness/BinaryRatio_FFC.m
@@ -34,4 +34,5 @@ bitStream = Byte2Bit_FFC(fragment);
 ZR = sum(bitStream == 0);
 OR = sum(bitStream == 1);
 
-BRO = ZR / OR;
+% Prevent zero division
+BRO = (ZR + 1) / (OR + 1)

--- a/02_Feature_Extraction/Randomness/BinaryRatio_FFC.m
+++ b/02_Feature_Extraction/Randomness/BinaryRatio_FFC.m
@@ -35,4 +35,4 @@ ZR = sum(bitStream == 0);
 OR = sum(bitStream == 1);
 
 % Prevent zero division
-BRO = (ZR + 1) / (OR + 1)
+BRO = (ZR + 1) / (OR + 1);

--- a/02_Feature_Extraction/Randomness/BinaryRatio_FFC.m
+++ b/02_Feature_Extraction/Randomness/BinaryRatio_FFC.m
@@ -34,4 +34,4 @@ bitStream = Byte2Bit_FFC(fragment);
 ZR = sum(bitStream == 0);
 OR = sum(bitStream == 1);
 
-BRO = ZR / OR;
+BRO = ZR / (OR + 1);

--- a/03_Parallel_Feature_Extraction/Randomness/BinaryRatio_Parallel_FFC.m
+++ b/03_Parallel_Feature_Extraction/Randomness/BinaryRatio_Parallel_FFC.m
@@ -39,5 +39,5 @@ parfor j=1:M
     ZR = sum(bitStream == 0);
     OR = sum(bitStream == 1);
     
-    BRO(j) = ZR / OR;
+    BRO(j) = (ZR + 1) / (OR + 1);
 end

--- a/12_Scripts_for_Datasets/Script_Parallel_GenerateDataset_from_FragmentDataset_FFC.m
+++ b/12_Scripts_for_Datasets/Script_Parallel_GenerateDataset_from_FragmentDataset_FFC.m
@@ -757,7 +757,7 @@ fprintf(fid,'The values in each row are: \n');
 for i=1:length(FeatureLabels)
     fprintf(fid,'%s,',FeatureLabels{i});
 end
-fprintf(fid,'Class Label (1,2,...), file identifier of the fragment\n');
+fprintf(fid,'Class Label, file ID\n');
 fprintf(fid,'---------------------------------------------- \n');
 fprintf(fid,'Class Label values are assigned as follows\n');
 for i=1:length(ClassLabels)

--- a/RUN.bat
+++ b/RUN.bat
@@ -1,0 +1,1 @@
+matlab -nodisplay -nosplash -nodesktop -r "Main_FFC"


### PR DESCRIPTION
### Zero Division
Prevent zero division in binary ratio features by adding 1 to both numerator and denominator.

## Minimal MATLAB Run
'Run.bat' prevents MATLAB from running it's GUI. Only a CLI and the Fragments Expert windows would open. This increases load time and run speed, and reduces memory usage.