### PR TITLE
Dataset CSV Export Improved

### DIFF
--- a/12_Scripts_for_Datasets/Script_Parallel_GenerateDataset_from_FragmentDataset_FFC.m
+++ b/12_Scripts_for_Datasets/Script_Parallel_GenerateDataset_from_FragmentDataset_FFC.m
@@ -757,7 +757,7 @@ fprintf(fid,'The values in each row are: \n');
 for i=1:length(FeatureLabels)
     fprintf(fid,'%s,',FeatureLabels{i});
 end
-fprintf(fid,'Class Label (1,2,...), file identifier of the fragment\n');
+fprintf(fid,'Class Label, file ID\n');
 fprintf(fid,'---------------------------------------------- \n');
 fprintf(fid,'Class Label values are assigned as follows\n');
 for i=1:length(ClassLabels)

--- a/RUN.bat
+++ b/RUN.bat
@@ -1,0 +1,1 @@
+matlab -nodisplay -nosplash -nodesktop -r "Main_FFC"


### PR DESCRIPTION
Modified the 4th line of the output file to be parsed more easily.

**Suggestions:**
- Put this line above the table. This way, every standard CVS reader would be able to parse them as table headers.